### PR TITLE
Enabling Travis CI and Coveralls source code coverage

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,31 @@
+#----------------------------
+# Git and SVN related
+#----------------------------
+^.svn
+^.git
+README[.]md
+
+#----------------------------
+# Travis-CI et al.
+#----------------------------
+^[.]travis[.]yml$
+^travis-tool[.]sh$
+^pkg-build[.]sh$
+^appveyor[.]yml$
+^covr-utils.R$
+^[.]coveralls[.]R$
+
+#----------------------------
+# R related
+#----------------------------
+^cran-comments[.].*$
+^vignettes/.*[.](pdf|PDF)$
+^vignettes/.*[.](r|R)$
+^vignettes/[.]install_extras$
 ^Makefile$
-^README.md$
+^incl
+^NAMESPACE,.*[.]txt$
+^nohup.*$
+^[.]devel
+^[.]test
+^[.]check

--- a/.coveralls.R
+++ b/.coveralls.R
@@ -1,0 +1,26 @@
+#################################################################
+# Test coverage
+#
+# * covr-utils: https://github.com/HenrikBengtsson/covr-utils
+# * covr: https://github.com/jimhester/covr
+# * Coveralls: https://coveralls.io/
+#
+# Henrik Bengtsson
+#################################################################
+if (!file_test("-f", "covr-utils.R")) {
+  source("http://callr.org/install#R.utils[u]")
+  R.utils::downloadFile("https://raw.githubusercontent.com/HenrikBengtsson/covr-utils/master/covr-utils.R")
+}
+
+source("covr-utils.R")
+
+# Exclusion rules
+excl <- exclusions(
+  filter(r_files(), covr_lines), # Apply 'covr:' rules in source code
+  filter(r_files(), stop_lines)  # Skip lines with stop().
+)
+str(excl)
+
+# Run through tests, record source code coverage, and
+# publish to Coveralls
+covr_package(exclusions=excl, quiet=FALSE)

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.Rhistory
+*~
+**/*~
+.check
+.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,72 @@
+#----------------------------------------------------------------
+# Travis-CI configuration for R packages
+#
+# REFERENCES:
+# * Travis CI: https://travis-ci.org/
+# * r-builder: https://github.com/metacran/r-builder
+# * covr: https://github.com/jimhester/covr
+# * Coveralls: https://coveralls.io/
+#
+# Validate your .travis.yml file at http://lint.travis-ci.org/
+#----------------------------------------------------------------
+language: c
+
+env:
+  global:
+    - RENV="./pkg-build.sh"  ## r-builder
+    - R_BUILD_ARGS="--no-manual"
+    - R_CHECK_ARGS="--no-manual --as-cran"
+    - _R_CHECK_FORCE_SUGGESTS_=false
+    # Need LaTeX? (very time consuming!)
+    - BOOTSTRAP_LATEX=""
+    # time consuming because LaTeX needs to be installed
+    - R_BUILD_ARGS="--no-build-vignettes ${R_BUILD_ARGS}"
+    - R_CHECK_ARGS="--no-build-vignettes ${R_CHECK_ARGS}"
+
+  # R versions r-builder should test on (ignored by r-travis)
+  matrix:
+#    - RVERSION=3.0.3
+#    - RVERSION=3.1.2
+    - RVERSION=devel
+
+
+before_install:
+  - echo RENV=$RENV
+  - curl -OL https://raw.githubusercontent.com/HenrikBengtsson/r-builder/master/pkg-build.sh;
+  - chmod 755 $RENV
+  - $RENV bootstrap
+  - if [ "BOOTSTRAP_LATEX" == "true" ]; then
+      (cd /tmp && curl -OL http://mirrors.ctan.org/macros/latex/contrib/xcolor.zip && cd /usr/share/texmf/tex/latex && sudo unzip /tmp/xcolor.zip && cd xcolor && sudo latex xcolor.ins && sudo texhash);
+    else
+      export R_RSP_COMPILELATEX_FALLBACK="copy-force";
+    fi
+
+install:
+  - $RENV install_r R.utils matrixStats R.cache digest snowfall
+  - $RENV install_bioc Biobase CGHbase CGHcall DNAcopy Rsamtools BSgenome GenomeInfoDb 
+## Less overhead when not using 'install_deps'
+##  - $RENV install_deps
+
+script:
+  - $RENV run_build
+  - $RENV run_check
+
+after_success:
+  - $RENV dump_logs_by_extension out
+  - $RENV install_devtools
+  - $RENV install_github HenrikBengtsson/R.methodsS3@develop
+  - $RENV install_github HenrikBengtsson/covr
+  - curl -OL https://raw.githubusercontent.com/HenrikBengtsson/covr-utils/master/covr-utils.R
+  - $RENV run_script .coveralls.R
+
+after_failure:
+  - $RENV dump_logs
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+
+branches:
+  except:
+   - /-expt$/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ because the two repositories use the [Bioconductor Git-SVN bridge][bridge]
 to mirror changes to the Bioconductor SVN repository, and the bridge can only
 use branch *master* of each GitHub repository.
 
+#### Software quality
+
+* R CMD check status:
+ - Bioconductor: <a href="http://master.bioconductor.org/checkResults/devel/bioc-LATEST/QDNAseq/">Multipleplatform build/check report</a>
+ - Travis CI: <a href="https://travis-ci.org/ccagc/QDNAseq"><img src="https://travis-ci.org/ccagc/QDNAseq.svg?branch=master" alt="Build status"></a>
+* Test coverage status:
+ - Coveralls CI: <a href='https://coveralls.io/r/ccagc/QDNAseq?branch=devel'><img src='https://coveralls.io/repos/ccagc/QDNAseq/badge.png?branch=devel' alt='Coverage Status' /></a>
+
 [bioc-devel]: http://bioconductor.org/packages/devel/bioc/html/QDNAseq.html
 [bioc-release]: http://bioconductor.org/packages/release/bioc/html/QDNAseq.html
 [bridge]: http://bioconductor.org/developers/how-to/git-svn/


### PR DESCRIPTION
This PR enables:
* Travis CI:
 - `R CMD build` and `R CMD check` of the package, e.g. https://travis-ci.org/HenrikBengtsson/QDNAseq/builds/48939471
 - Code coverage of tests by [covr](https://github.com/jimhester/covr), e.g. expand last bullet point in above Travis URL.
* Coveralls:
 - Above 'covr' results are automatically sent to Coveralls for detailed view of code coverage, e.g. https://coveralls.io/jobs/4231050
* Adds status Travis CI and Coveralls badges to README and a link to Bioc devel check results.

The covr/Coveralls feature is outstanding in the sense that it will improve the quality, because I'll bet you big time that the code currently not tested has bugs.  That's just the nature of universe.


What you (=ccagc) need to do:
* Travis CI:
 - Signup/sign-in at https://travis-ci.org/ with your GitHub account.  
 - Go to https://travis-ci.org/profile/ccagc/, sync repositories, and "enable" the QDNAseq repository.
* Coveralls:
 - Signup/sign-in at https://coveralls.io/ with your GitHub account.
 - Go to https://coveralls.io/repos/, sync repositories, and "enable" the QDNAseq repository.

Next time you push something to your GitHub repository, you'll see that Travis CI starts running (https://travis-ci.org/ccagc/QDNAseq/).  QDNAseq has quite a few heavy BioC dependencies so it'll take 10-15 mins to complete the whole process.




