### PR TITLE
Remove requirement for chromosome names to be integers/X/Y/MT

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: QDNAseq
-Version: 1.5.2
-Date: 2015-08-11
+Version: 1.5.3
+Date: 2015-08-25
 Title: Quantitative DNA sequencing for chromosomal aberrations
 Author: Ilari Scheinin [aut], Daoud Sie [aut, cre], Henrik Bengtsson [aut]
 Maintainer: Daoud Sie <d.sie@vumc.nl>

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,29 @@
+Changes in version 1.6.0 (2015-xx-yy)
+-------------------------------------
+
+RELEASE
+
+    o Bioconductor 3.2
+
+IMPROVEMENTS
+
+    o chromosomes() no longer tries to return chromosome names as an integer
+      vector, but returns a character vector instead
+
+BUG FIXES
+
+    o plot() and calculateMappability() now work also for other chromosome
+      names besides numbers and "X", "Y", and "MT"
+
+Changes in version 1.4.2 (2015-08-20)
+-------------------------------------
+
+BUG FIXES
+
+    o createBins() now properly selects chromosomes when ignoring 
+      mitochondrial DNA. Please note that the mitochondrial DNA is only 
+      ignored when it is called either "chrMT", "chrM", "MT", or "M"
+
 Changes in version 1.4.1 (2015-06-30)
 -------------------------------------
 

--- a/R/QDNAseqSignals-accessors.R
+++ b/R/QDNAseqSignals-accessors.R
@@ -43,10 +43,7 @@ setMethod("binsToUse", signature=c(object="AnnotatedDataFrame"),
 setMethod("chromosomes", signature=c(object="QDNAseqSignals"),
     definition=function(object) {
     
-    tmp <- fData(object)$chromosome
-    tmp[tmp=="X"] <- "23"
-    tmp[tmp=="Y"] <- "24"
-    as.integer(tmp)
+    fData(object)$chromosome
 })
 
 setMethod("bpstart", signature=c(object="QDNAseqSignals"),

--- a/R/createBinAnnotations.R
+++ b/R/createBinAnnotations.R
@@ -64,7 +64,7 @@ createBins <- function(bsgenome, binSize, ignoreMitochondria=TRUE,
     }
     if (ignoreMitochondria) {
         selectedMT <- grep("^(chr)?M(T)?$", chrs)
-	if (length(selectedMT) != 0)
+        if (length(selectedMT) != 0)
             chrs <- chrs[-selectedMT]
     }
     lengths <- GenomeInfoDb::seqlengths(bsgenome)[chrs]
@@ -138,12 +138,14 @@ calculateBlacklist <- function(bins, bedFiles, ncpus=1) {
     colnames(combined) <- c("chromosome", "start", "end")
     combined$chromosome <- sub("^chr", "", combined$chromosome)
     combined <- combined[combined$chromosome %in% unique(bins$chromosome), ]
-    combined$chromosome[combined$chromosome=="X"] <- "23"
-    combined$chromosome[combined$chromosome=="Y"] <- "24"
-    combined$chromosome <- as.integer(combined$chromosome)
     combined <- combined[!is.na(combined$chromosome), ]
     combined$start <- combined$start + 1
-    combined <- combined[order(combined$chromosome, combined$start), ]
+    ## define correct sorting order of chromosomes as the order in which they
+    ## are in the bins
+    chromosomes <- unique(bins$chromosome)
+    chromosomeOrder <- factor(combined$chromosome, levels=chromosomes,
+       ordered=TRUE)
+    combined <- combined[order(chromosomeOrder, combined$start), ]
     joined <- data.frame()
     prev <- combined[1L,]
     # Sanity check
@@ -158,9 +160,6 @@ calculateBlacklist <- function(bins, bedFiles, ncpus=1) {
         }
     }
     joined <- rbind(joined, prev)
-    bins$chromosome[bins$chromosome=="X"] <- "23"
-    bins$chromosome[bins$chromosome=="Y"] <- "24"
-    bins$chromosome <- as.integer(bins$chromosome)
     overlap.counter <- function(x, joined) {
         chr <- as.integer(x["chromosome"])
         start <- as.integer(x["start"])

--- a/R/exportBins.R
+++ b/R/exportBins.R
@@ -26,6 +26,12 @@
 #     \item{logTransform}{If @TRUE (default), data will be log2-transformed.}
 #     \item{digits}{The number of digits to round to. If not @numeric, no
 #         no rounding is performed.}
+#     \item{chromosomeReplacements}{A named character vector of chromosome name
+#         replacements to be done. Only used when \code{object} is of class
+#         @see "cghRaw", @see "cghSeg", @see "cghCall", or @see "cghRegions",
+#        since these classes store chromosome names as integers, whereas all
+#        QDNAseq object types use character vectors. Defaults to
+#         \code{c("23"="X", "24"="Y", "25"="MT")} for human.}
 #     \item{...}{Additional arguments passed to @see "utils::write.table".}
 # }
 #
@@ -53,7 +59,8 @@
 #*/#########################################################################
 exportBins <- function(object, file, format=c("tsv", "igv", "bed"),
     type=c("copynumber", "segments", "calls"),
-    filter=TRUE, logTransform=TRUE, digits=3, ...) {
+    filter=TRUE, logTransform=TRUE, digits=3,
+    chromosomeReplacements=c("23"="X", "24"="Y", "25"="MT"), ...) {
 
     format <- match.arg(format)
     type <- match.arg(type)
@@ -91,9 +98,10 @@ exportBins <- function(object, file, format=c("tsv", "igv", "bed"),
 
         feature <- featureNames(object)
         chromosome <- as.character(chromosomes(object))
-        chromosome[chromosome == "23"] <- "X"
-        chromosome[chromosome == "24"] <- "Y"
-        chromosome[chromosome == "25"] <- "MT"
+        for (chromosomeReplacement in names(chromosomeReplacements)) {
+          chromosome[chromosome == chromosomeReplacement] <-
+            chromosomeReplacements[chromosomeReplacement]
+        }
         start <- bpstart(object)
         end <- bpend(object)
         if (inherits(object, c("cghRaw", "cghSeg", "cghCall"))) {

--- a/R/makeCgh.R
+++ b/R/makeCgh.R
@@ -14,6 +14,10 @@
 # \arguments{
 #     \item{object}{A @see "QDNAseqCopyNumbers" object.}
 #     \item{filter}{If @TRUE, bins are filtered, otherwise not.}
+#     \item{chromosomeReplacements}{A named integer vector of chromosome name
+#         replacements to be done. QDNAseq stores chromosome names as
+#         characters, but CGHcall expects them to be integers. Defaults to
+#         \code{c(X=23, Y=24, MT=25)} for human.}
 #     \item{...}{Not used.}
 # }
 #
@@ -39,7 +43,8 @@
 # @keyword manip
 #*/#########################################################################
 setMethod('makeCgh', signature=c(object='QDNAseqCopyNumbers'),
-    definition=function(object, filter=TRUE, ...) {
+    definition=function(object, filter=TRUE,
+      chromosomeReplacements=c(X=23, Y=24, MT=25), ...) {
 
     # Decide which cgh* class to create
     names <- assayDataElementNames(object)
@@ -67,7 +72,12 @@ setMethod('makeCgh', signature=c(object='QDNAseqCopyNumbers'),
     }
 
     # Coerce chromosomes to integer indices
-    fData(object)$chromosome <- chromosomes(object)
+    tmp <- chromosomes(object)
+    for (chromosomeReplacement in names(chromosomeReplacements)) {
+      tmp[tmp == chromosomeReplacement] <-
+        chromosomeReplacements[chromosomeReplacement]
+    }
+    fData(object)$chromosome <- as.integer(tmp)
 
     # Update column names
     names <- colnames(fData(object))

--- a/R/plot-methods.R
+++ b/R/plot-methods.R
@@ -90,6 +90,8 @@ setMethod("plot", signature(x="QDNAseqSignals", y="missing"),
     all.chrom <- chromosomes(x)
     chrom <- all.chrom[condition]
     uni.chrom <- unique(chrom)
+    chrom.num <- as.integer(factor(chrom, levels=uni.chrom, ordered=TRUE))
+    uni.chrom.num <- unique(chrom.num)
     if (!scale) {
         pos <- pos2 <- 1:sum(condition)
         chrom.ends <- aggregate(pos,
@@ -105,13 +107,17 @@ setMethod("plot", signature(x="QDNAseqSignals", y="missing"),
         }
         pos <- as.numeric(bpstart(x)[condition])
         pos2 <- as.numeric(bpend(x)[condition])
-        chrom.lengths <- chrom.lengths[as.character(uni.chrom)]
+        chrom.lengths <- chrom.lengths[uni.chrom]
         chrom.ends <- integer()
         cumul <- 0
-        for (i in uni.chrom) {
-            pos[chrom > i] <- pos[chrom > i] + chrom.lengths[as.character(i)]
-            pos2[chrom > i] <- pos2[chrom > i] + chrom.lengths[as.character(i)]
-            cumul <- cumul + chrom.lengths[as.character(i)]
+        for (i in seq_along(uni.chrom)) {
+            pos[chrom.num > uni.chrom.num[i]] <-
+                pos[chrom.num > uni.chrom.num[i]] +
+                chrom.lengths[uni.chrom[i]]
+            pos2[chrom.num > uni.chrom.num[i]] <-
+              pos2[chrom.num > uni.chrom.num[i]] +
+              chrom.lengths[uni.chrom[i]]
+            cumul <- cumul + chrom.lengths[uni.chrom[i]]
             chrom.ends <- c(chrom.ends, cumul)
         }
         names(chrom.ends) <- names(chrom.lengths)
@@ -309,15 +315,21 @@ setMethod("frequencyPlot", signature=c(x="QDNAseqCopyNumbers", y="missing"),
     }
     chrom <- all.chrom[condition]
     uni.chrom <- unique(chrom)
-    chrom.lengths <- chrom.lengths[as.character(uni.chrom)]
+    chrom.num <- as.integer(factor(chrom, levels=uni.chrom, ordered=TRUE))
+    uni.chrom.num <- unique(chrom.num)
+    chrom.lengths <- chrom.lengths[uni.chrom]
     pos <- as.numeric(bpstart(x)[condition])
     pos2 <- as.numeric(bpend(x)[condition])
     chrom.ends <- integer()
     cumul <- 0
-    for (i in uni.chrom) {
-        pos[chrom > i] <- pos[chrom > i] + chrom.lengths[as.character(i)]
-        pos2[chrom > i] <- pos2[chrom > i] + chrom.lengths[as.character(i)]
-        cumul <- cumul + chrom.lengths[as.character(i)]
+    for (i in seq_along(uni.chrom)) {
+        pos[chrom.num > uni.chrom.num[i]] <-
+            pos[chrom.num > uni.chrom.num[i]] +
+            chrom.lengths[uni.chrom[i]]
+        pos2[chrom.num > uni.chrom.num[i]] <-
+          pos2[chrom.num > uni.chrom.num[i]] +
+          chrom.lengths[uni.chrom[i]]
+        cumul <- cumul + chrom.lengths[uni.chrom[i]]
         chrom.ends <- c(chrom.ends, cumul)
     }
     names(chrom.ends) <- names(chrom.lengths)

--- a/man/createBins.Rd
+++ b/man/createBins.Rd
@@ -17,7 +17,7 @@
 \title{Builds bin annotation data for a particular bin size}
 
 \usage{
-createBins(bsgenome, binSize, ignoreMitochondria=TRUE)
+createBins(bsgenome, binSize, ignoreMitochondria=TRUE, excludeSeqnames=NULL)
 }
 
 \description{
@@ -29,7 +29,9 @@ createBins(bsgenome, binSize, ignoreMitochondria=TRUE)
     \item{binSize}{A \code{\link[base]{numeric}} scalar specifying the width of the bins
         in units of kbp (1000 base pairs), e.g. \code{binSize=15} corresponds
         to 15 kbp bins.}
-    \item{ignoreMitochondria}{Wheter to ignore the mitochondria.}
+    \item{ignoreMitochondria}{Whether to ignore the mitochondria.}
+    \item{excludeSeqnames}{Character vector of seqnames which should be
+        ignored.}
 }
 
 \value{

--- a/man/exportBins.Rd
+++ b/man/exportBins.Rd
@@ -16,7 +16,8 @@
 
 \usage{
 exportBins(object, file, format=c("tsv", "igv", "bed"), type=c("copynumber", "segments",
-  "calls"), filter=TRUE, logTransform=TRUE, digits=3, ...)
+  "calls"), filter=TRUE, logTransform=TRUE, digits=3,
+  chromosomeReplacements=c(`23` = "X", `24` = "Y", `25` = "MT"), ...)
 }
 
 \description{
@@ -38,6 +39,12 @@ exportBins(object, file, format=c("tsv", "igv", "bed"), type=c("copynumber", "se
     \item{logTransform}{If \code{\link[base:logical]{TRUE}} (default), data will be log2-transformed.}
     \item{digits}{The number of digits to round to. If not \code{\link[base]{numeric}}, no
         no rounding is performed.}
+    \item{chromosomeReplacements}{A named character vector of chromosome name
+        replacements to be done. Only used when \code{object} is of class
+        \code{\link{cghRaw}}, \code{\link{cghSeg}}, \code{\link{cghCall}}, or \code{\link{cghRegions}},
+       since these classes store chromosome names as integers, whereas all
+       QDNAseq object types use character vectors. Defaults to
+        \code{c("23"="X", "24"="Y", "25"="MT")} for human.}
     \item{...}{Additional arguments passed to \code{\link[utils]{write.table}}.}
 }
 

--- a/man/getBinAnnotations.Rd
+++ b/man/getBinAnnotations.Rd
@@ -13,7 +13,7 @@
 \title{Gets bin annotation data for a particular bin size}
 
 \usage{
-getBinAnnotations(binSize, genome="hg19", type="SR50", force=FALSE,
+getBinAnnotations(binSize, genome="hg19", type="SR50",
   path=getOption("QDNAseq::binAnnotationPath", "http://qdnaseq.s3.amazonaws.com"))
 }
 
@@ -29,8 +29,6 @@ getBinAnnotations(binSize, genome="hg19", type="SR50", force=FALSE,
        to be used.}
     \item{type}{A \code{\link[base]{character}} string specify the experiment type, e.g. "SR50"
        or "PE100".}
-    \item{force}{If \code{\link[base:logical]{TRUE}}, the bin anonnation data is retrieved/calculated
-       regardless of it already exists in the cache or not.}
     \item{path}{A \code{\link[base]{character}} string specifying the path for the bin
         annotation files. Defaults to downloading from the Internet, but can
         also be a local path. Can also be defined by setting the

--- a/man/makeCgh.Rd
+++ b/man/makeCgh.Rd
@@ -25,6 +25,10 @@ makeCgh(object, filter=TRUE, ...)
 \arguments{
     \item{object}{A \code{\link{QDNAseqCopyNumbers}} object.}
     \item{filter}{If \code{\link[base:logical]{TRUE}}, bins are filtered, otherwise not.}
+    \item{chromosomeReplacements}{A named integer vector of chromosome name
+        replacements to be done. QDNAseq stores chromosome names as
+        characters, but CGHcall expects them to be integers. Defaults to
+        \code{c(X=23, Y=24, MT=25)} for human.}
     \item{...}{Not used.}
 }
 


### PR DESCRIPTION
Previously chromosomes() has returned an integer vector (changing "X"->23, "Y"->24, "MT"->25), which meant chromosome names could not be anything else besides numbers and those three character strings. This pull request changes chromosomes() to return a character instead of integer vector.

plot(), frequenclyPlot(), calculateMappability(), exportBins(), and makeCgh() have also been updated since they all contained hard-coded assumptions on chromosome names.