### PR TITLE
Fix four bugs, mostly involving use of custom bin annotations

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,17 @@
+Changes in version 1.7.3 (2016-xx-xx)
+-------------------------------------
+
+BUG FIXES 
+
+    o applyFilters() and highlightFilters() now work properly when using a
+      numerical value for parameter residual
+    o highlightFilters() no longer highlights entire chromosomes for which
+      the residual filter is missing altogether, which matches the behavior of
+      applyFilters()
+    o getBinAnnotations() now allows custom bin annotations to be loaded via
+      the path parameter even when an annotation package has been installed
+    o phenodata files with a single variable are now handled correctly
+
 Changes in version 1.7.2 (2015-12-18)
 -------------------------------------
 

--- a/R/addPhenodata.R
+++ b/R/addPhenodata.R
@@ -37,7 +37,8 @@
 addPhenodata <- function(object, phenofile) {
     pdata <- read.table(phenofile, header=TRUE, sep='\t', as.is=TRUE,
         row.names=1L)
-    pData(object) <- cbind(pData(object), pdata[sampleNames(object), ])
+    pData(object) <- cbind(pData(object), pdata[sampleNames(object), ,
+        drop=FALSE])
     object
 }
 

--- a/R/applyFilters.R
+++ b/R/applyFilters.R
@@ -29,8 +29,8 @@
 #         bases (not Ns) in the reference genome sequence. NA (default) or
 #         @FALSE will not filted based on uncharacterized bases.}
 #     \item{chromosomes}{A @character vector specifying which chromosomes
-#         to filter out. Defaults to the sex chromosomes,
-#         i.e. \code{c("X", "Y")}.}
+#         to filter out. Defaults to the sex chromosomes and mitochondria,
+#         i.e. \code{c("X", "Y", "MT")}.}
 # }
 #
 # \value{
@@ -49,7 +49,7 @@
 #*/#########################################################################
 setMethod('applyFilters', signature=c(object='QDNAseqReadCounts'),
     definition=function(object, residual=TRUE, blacklist=TRUE, mappability=NA,
-    bases=NA, chromosomes=c("X", "Y")) {
+    bases=NA, chromosomes=c("X", "Y", "MT")) {
 
     condition <- rep(TRUE, times=nrow(object))
     msg <- c('total bins'=sum(condition))

--- a/R/applyFilters.R
+++ b/R/applyFilters.R
@@ -60,6 +60,7 @@ setMethod('applyFilters', signature=c(object='QDNAseqReadCounts'),
 
     if (!is.na(residual)) {
         residuals <- fData(object)$residual
+        cutoff <- residual * madDiff(residuals, na.rm=TRUE)
         residualsMissing <- aggregate(residuals,
             by=list(chromosome=fData(object)$chromosome),
             function(x) all(is.na(x)))
@@ -74,7 +75,7 @@ setMethod('applyFilters', signature=c(object='QDNAseqReadCounts'),
         }
         if (is.numeric(residual)) {
             condition <- condition & !is.na(residuals) &
-                abs(residuals) <= residual
+                abs(residuals) <= cutoff
         } else if (residual) {
             condition <- condition & !is.na(residuals)
         }

--- a/R/binReadCounts.R
+++ b/R/binReadCounts.R
@@ -21,7 +21,7 @@
 #         file names with extension ext removed.}
 #     \item{phenofile}{An optional character(1) specifying a file name for
 #         phenotype data.}
-#     \item{chunkSize} {An optional integer specifying the chunk size (nt) by 
+#     \item{chunkSize}{An optional integer specifying the chunk size (nt) by 
 #         which to process the bam file.}
 #     \item{cache}{Whether to read and write intermediate cache files, which
 #         speeds up subsequent analyses of the same files. Requires packages
@@ -84,7 +84,7 @@
 # }
 # }
 #
-# @author "IS"
+# @author "IS,DS"
 #
 # @keyword IO
 # @keyword file

--- a/R/binReadCounts.R
+++ b/R/binReadCounts.R
@@ -117,7 +117,7 @@ binReadCounts <- function(bins, bamfiles=NULL, path=NULL, ext='bam',
     if (!is.null(phenofile)) {
         pdata <- read.table(phenofile, header=TRUE, sep='\t', as.is=TRUE,
             row.names=1L)
-        phenodata <- cbind(phenodata, pdata[rownames(phenodata), ])
+        phenodata <- cbind(phenodata, pdata[rownames(phenodata), , drop=FALSE])
     }
 
     if (class(bins) == 'data.frame')

--- a/man/QDNAseq-package.Rd
+++ b/man/QDNAseq-package.Rd
@@ -32,9 +32,10 @@
 
 \section{How to cite this package}{
     Whenever using this package, please cite:
-    Scheinin I, Sie D, Bengtsson H, van de Wiel MA, Olshen AB, van Thuijl HF, van Essen HF, Eijk PP, Rustenburg F, Meijer GA, Reijneveld JC, Wesseling P, Pinkel D, Albertson DG and Ylstra B
-(2014). "DNA copy number analysis of fresh and formalin-fixed specimens by shallow whole-genome sequencing with identification and exclusion of problematic regions in the genome
-assembly." _Genome Research_, *24*, pp. 2022-2032.
+    Scheinin I, Sie D, Bengtsson H, van de Wiel MA, Olshen AB, van Thuijl HF, van Essen HF, Eijk PP, Rustenburg F, Meijer GA,
+Reijneveld JC, Wesseling P, Pinkel D, Albertson DG and Ylstra B (2014). "DNA copy number analysis of fresh and
+formalin-fixed specimens by shallow whole-genome sequencing with identification and exclusion of problematic regions in the
+genome assembly." _Genome Research_, *24*, pp. 2022-2032.
 }
 
 \author{Ilari Scheinin}

--- a/man/QDNAseq-package.Rd
+++ b/man/QDNAseq-package.Rd
@@ -33,8 +33,8 @@
 \section{How to cite this package}{
     Whenever using this package, please cite:
     Scheinin I, Sie D, Bengtsson H, van de Wiel MA, Olshen AB, van Thuijl HF, van Essen HF, Eijk PP, Rustenburg F, Meijer GA, Reijneveld JC, Wesseling P, Pinkel D, Albertson DG and Ylstra B
-(2014). "DNA copy number analysis of fresh and formalin-fixed specimens by shallow whole-genome sequencing with identification and exclusion of problematic regions in the genome assembly."
-_Genome Research_, *24*, pp. 2022-2032.
+(2014). "DNA copy number analysis of fresh and formalin-fixed specimens by shallow whole-genome sequencing with identification and exclusion of problematic regions in the genome
+assembly." _Genome Research_, *24*, pp. 2022-2032.
 }
 
 \author{Ilari Scheinin}

--- a/man/applyFilters.Rd
+++ b/man/applyFilters.Rd
@@ -41,8 +41,8 @@ applyFilters(object, residual=TRUE, blacklist=TRUE, mappability=NA, bases=NA,
         bases (not Ns) in the reference genome sequence. NA (default) or
         \code{\link[base:logical]{FALSE}} will not filted based on uncharacterized bases.}
     \item{chromosomes}{A \code{\link[base]{character}} vector specifying which chromosomes
-        to filter out. Defaults to the sex chromosomes,
-        i.e. \code{c("X", "Y")}.}
+        to filter out. Defaults to the sex chromosomes and mitochondria,
+        i.e. \code{c("X", "Y", "MT")}.}
 }
 
 \value{

--- a/man/binReadCounts.Rd
+++ b/man/binReadCounts.Rd
@@ -13,11 +13,10 @@
 \title{Calculate binned read counts from a set of BAM files}
 
 \usage{
-binReadCounts(bins, bamfiles=NULL, path=NULL, ext="bam", bamnames=NULL,
-  phenofile=NULL, chunkSize=NULL, cache=getOption("QDNAseq::cache", FALSE),
-  force=!cache, isPaired=NA, isProperPair=NA, isUnmappedQuery=FALSE,
-  hasUnmappedMate=NA, isMinusStrand=NA,isMateMinusStrand=NA, 
-  isFirstMateRead=NA, isSecondMateRead=NA, isSecondaryAlignment=NA,
+binReadCounts(bins, bamfiles=NULL, path=NULL, ext="bam", bamnames=NULL, phenofile=NULL,
+  chunkSize=NULL, cache=getOption("QDNAseq::cache", FALSE), force=!cache, isPaired=NA,
+  isProperPair=NA, isUnmappedQuery=FALSE, hasUnmappedMate=NA, isMinusStrand=NA,
+  isMateMinusStrand=NA, isFirstMateRead=NA, isSecondMateRead=NA, isSecondaryAlignment=NA,
   isNotPassingQualityControls=FALSE, isDuplicate=FALSE, minMapq=37)
 }
 
@@ -101,6 +100,7 @@ readCounts <- binReadCounts(bins)
 }
 
 \author{Ilari Scheinin, Daoud Sie}
+
 
 
 \keyword{IO}

--- a/man/callBins.Rd
+++ b/man/callBins.Rd
@@ -24,10 +24,10 @@ callBins(object, organism=c("human", "other"), ...)
 
 \arguments{
     \item{object}{An object of class QDNAseqCopyNumbers}
-    \item{organism}{Either \dQuote{human} or \dQuote{other}, see manual page for
-        \code{\link[CGHcall]{CGHcall}} for more details. This is only used for
-        chromosome arm information when \dQuote{prior} is set to \dQuote{all} or
-        \dQuote{auto} (and samplesize > 20).}
+    \item{organism}{Either \dQuote{human} or \dQuote{other}, see manual page
+        for \code{\link[CGHcall]{CGHcall}} for more details. This is only used for
+        chromosome arm information when \dQuote{prior} is set to \dQuote{all}
+        or \dQuote{auto} (and samplesize > 20).}
     \item{...}{Additional arguments passed to \code{\link[CGHcall]{CGHcall}}.}
 }
 

--- a/man/getBinAnnotations.Rd
+++ b/man/getBinAnnotations.Rd
@@ -14,7 +14,7 @@
 
 \usage{
 getBinAnnotations(binSize, genome="hg19", type="SR50",
-  path=getOption("QDNAseq::binAnnotationPath", "http://qdnaseq.s3.amazonaws.com"))
+  path=getOption("QDNAseq::binAnnotationPath", NULL))
 }
 
 \description{


### PR DESCRIPTION
Fixes a total of four bugs, mostly involving situations where custom bin annotations are used.

1. When a numerical value is used for parameter residual of applyFilters(), it should (according to manual pages) correspond to "the cutoff as number of standard deviations estimated with madDiff". However, instead of multiplying the supplied parameter value with the calculated standard deviation, the parameter value was used directly. This is now fixed. When a boolean value was used for the parameter (the default is TRUE), everything was fine. In practice, the bug only affected situations with custom-made bin annotations.

2. Same as above, but for highlightFilters().

3. When using the residual filter, applyFilters() used to remove chromosomes for which the filter was missing altogether (for the pre-generated bin annotations this meant X and Y). This was changed a while ago, but highlightFilters() still followed the old behavior. This is now fixed. Out of the four bugs, this is the only one that has an effect when using pre-generated bin annotations.

4. When an annotation package was present, it blocked the possibility to load other bin annotations for the same genome build via the path parameter. This is now fixed.

Also a couple of other small changes. Because of the bug fixes, this should be incorporated to both the development and release versions of Bioconductor. It could make sense though to first merge with development, and after a bit more/wider testing, to do the same with the release.