### PR TITLE
Prepare for update in matrixStats where colMedians() is no longer an S4 method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: QDNAseq
-Version: 1.9.1
-Date: 2016-05-24
+Version: 1.9.1-9000
+Date: 2016-07-11
 Title: Quantitative DNA sequencing for chromosomal aberrations
 Author: Ilari Scheinin [aut], Daoud Sie [aut, cre], Henrik Bengtsson [aut]
 Maintainer: Daoud Sie <d.sie@vumc.nl>

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -13,7 +13,6 @@ importMethodsFrom(CGHbase, bpend, bpstart, calls, "calls<-", chromosomes,
     copynumber, "copynumber<-", frequencyPlot, plot, probamp, "probamp<-",
     probdloss, "probdloss<-", probgain, "probgain<-", probloss, "probloss<-",
     probnorm, "probnorm<-", segmented, "segmented<-", "regions", "regions<-")
-importMethodsFrom(matrixStats, colMedians)
 importMethodsFrom(methods, coerce, initialize, show)
 importMethodsFrom(Rsamtools, scanBam, ScanBamParam, scanBamHeader)
 
@@ -23,7 +22,7 @@ importFrom(CGHcall, CGHcall, ExpandCGHcall, postsegnormalize)
 importFrom(DNAcopy, CNA, segment, smooth.CNA, segments.summary)
 importFrom(graphics, abline, axis, axTicks, box, contour, image, mtext, par,
     points, rect, segments, text)
-importFrom(matrixStats, binCounts, madDiff, sdDiff, rowMedians)
+importFrom(matrixStats, binCounts, madDiff, sdDiff, rowMedians, colMedians)
 importFrom(methods, callNextMethod, new)
 importFrom(R.utils, downloadFile)
 importFrom(Rsamtools, scanBamFlag)


### PR DESCRIPTION
I'm planning to (finally) turn col-/rowMedians() for matrixStats into a plain function - for historical reasons they're currently S4 methods, but that will change. In order for QDNAseq not to break when that happens, this patch needs to be applied.

For more details on the matrixStats update, see HenrikBengtsson/matrixStats#80