### PR TITLE
Parallelize binReadCounts by chromosome when chunkSize is used

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ Imports: graphics, methods, stats, utils,
         Biobase (>= 2.18.0), CGHbase (>= 1.18.0), CGHcall (>= 2.18.0),
         DNAcopy (>= 1.32.0), GenomicRanges (>= 1.20), IRanges (>= 2.2),
         matrixStats (>= 0.50.2), R.utils (>= 2.3.0), Rsamtools (>= 1.20),
+        BiocParallel (>= 1.6.6),
 Suggests: BiocStyle (>= 1.8.0), BSgenome (>= 1.38.0), digest (>= 0.6.8),
         GenomeInfoDb (>= 1.6.0), future (>= 0.14.0), R.cache (>= 0.12.0)
 Description: Quantitative DNA sequencing for chromosomal aberrations.

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -30,6 +30,7 @@ importFrom(stats, aggregate, approxfun, density, formula, lm, loess, median, pre
 importFrom(utils, data, maintainer, packageVersion, read.table, write.table)
 importFrom(GenomicRanges, GRanges)
 importFrom(IRanges, IRanges)
+importFrom(BiocParallel, bplapply)
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # EXPORTS

--- a/vignettes/QDNAseq.Rnw
+++ b/vignettes/QDNAseq.Rnw
@@ -83,6 +83,12 @@ files will be used as input in future \R{} sessions, option \Rcode{cache=TRUE}
 can be used to cache intermediate files, which will speed up future analyses.
 Caching is done with package \CRANpkg{R.cache}.
 
+For large BAM files it is advisable to use the \Rcode{chunkSize} parameter to
+control memory usage. A non-\Rcode{NULL}, non-numeric value will use the length
+of the longest chromosome, effectively chunking by chromosome. A numeric value
+will use that many reads at a time. Note that total peak memory usage is
+controlled both by the chunk size and the number of parallel workers. See \autoref{sec:parallel}.
+
 For the purpose of this tutorial, we load an example data set of chromosomes
 7--10 of low grade glioma sample LGG150.
 
@@ -295,6 +301,7 @@ objects by running it before segmentation or calling.
 \clearpage
 
 \section{Parallel computation}
+\label{sec:parallel}
 
 \Biocpkg{QDNAseq} supports parallel computing via the \CRANpkg{future} package.
 After installing it with \Rcode{install.packages("future")}, all that is
@@ -304,7 +311,10 @@ that is to include it in your \file{$\sim$/.Rprofile}.
 The instructions below apply to all of \Biocpkg{QDNAseq}'s own functions that
 support parallel processing. At the moment these include
 \Rfunction{estimateCorrection()}, \Rfunction{segmentBins()},
-\Rfunction{createBins()}, and \Rfunction{calculateBlacklist()}.
+\Rfunction{createBins()}, and \Rfunction{calculateBlacklist()}. \Rfunction{binReadCounts()}
+parallelizes by chromosome when \Rcode{chunkSize} is used. The parallel
+environment used for this can be controlled using \Biocpkg{BiocParallel}'s
+standard configuration methods (e.g. \Rfunction{register()}, \Robject{mc.cores}).
 
 However, when argument \Rcode{method="CGHcall"} (which is the default),
 function \Rfunction{callBins()} calls function \Rfunction{CGHcall()} from


### PR DESCRIPTION
This functionality is on by default, with the default BiocParallel
environment for the host machine. Often this means process-based
parallelism with number of workers equal to number of cores minus two.

BiocParallel allows client code to configure the parallel environment
without explicitly passing any parameters into binReadCounts, so
changing this default can be done per the documentation:

```
register(MulticoreParam(workers=8))
readCounts <- binReadCounts(bins, bams, chunkSize=TRUE)
```

There are further opportunities for parallelism: at the chunk level,
the file level and also in the non-chunked version. File-level
parallelism is rather easy to arrange outside of QDNAseq. Chunk-level
parallelism currently seems unnecessary when already parallelizing by
chromosome (especially since chunking by entire chromosomes fits in a few
GB of memory).