### PR TITLE
prevent rle combining across no copynumber change 

### DIFF
--- a/R/exportBins.R
+++ b/R/exportBins.R
@@ -191,7 +191,7 @@ exportVCF <- function(obj) {
 
     for (i in 1:ncol(calls)) {	
 	d <- cbind(fd[,1:3], calls[,i], segments[,i])
-	sel <- d[,4] != 0 & !is.na(d[,4])
+	sel <- !is.na(d[,4])
 
 	dsel <- d[sel,]
 
@@ -234,7 +234,7 @@ exportVCF <- function(obj) {
 	fname <- paste(pd$name[i], ".vcf", sep="")
 
 	write.table(vcfHeader, fname, quote=FALSE, sep="\t", col.names=FALSE, row.names=FALSE)
-	suppressWarnings(write.table(out, fname, quote=FALSE, sep="\t", append=TRUE, col.names=TRUE, row.names=FALSE))
+	suppressWarnings(write.table(out[dsel[posI,4] != 0,], fname, quote=FALSE, sep="\t", append=TRUE, col.names=TRUE, row.names=FALSE))
     }
 }
 
@@ -260,7 +260,7 @@ exportSEG <- function(obj, fnames=NULL) {
 
     for (i in 1:ncol(calls)) {	
 	d <- cbind(fd[,1:3],calls[,i], segments[,i])
-	sel <- d[,4] != 0 & !is.na(d[,4])
+	sel <- !is.na(d[,4])
 
 	dsel <- d[sel,]
 
@@ -281,7 +281,7 @@ exportSEG <- function(obj, fnames=NULL) {
 
 	fname <- paste(fnames[i], ".seg", sep="")
 
-	write.table(out, fname, quote=FALSE, sep="\t", append=FALSE, col.names=TRUE, row.names=FALSE)
+	write.table(out[dsel[posI,4] != 0,], fname, quote=FALSE, sep="\t", append=FALSE, col.names=TRUE, row.names=FALSE)
     }
 }
 


### PR DESCRIPTION
Hi Daoud,

I observed this in the output where segments interleaved with segments of no-copynumber change where combined.

Roel

Before change:
3	31665001	.	<DIP>	<DUP>	1000	PASS	SVTYPE=DUP;END=62325000;SVLEN=30660000;BINS=820;SCORE=1;LOG2CNT=0.58	GT	0/1

After:
3	31665001	.	<DIP>	<DUP>	1000	PASS	SVTYPE=DUP;END=39870000;SVLEN=8205000;BINS=527;SCORE=1;LOG2CNT=0.58	GT	0/1
3	48525001	.	<DIP>	<DUP>	1000	PASS	SVTYPE=DUP;END=51675000;SVLEN=3150000;BINS=198;SCORE=1;LOG2CNT=0.59	GT	0/1
3	60870001	.	<DIP>	<DUP>	1000	PASS	SVTYPE=DUP;END=62325000;SVLEN=1455000;BINS=95;SCORE=1;LOG2CNT=0.55	GT	0/1