### PR TITLE
Prevent data.frames from turning into vectors

### DIFF
--- a/R/exportBins.R
+++ b/R/exportBins.R
@@ -285,7 +285,7 @@ exportVCF <- function(obj, fnames) {
         colnames(out) <- c("#CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT", pd$name[i])
 
         ## Drop copy-neutral segments
-        out <- out[dsel[posI, 4] != 0, ]
+        out <- out[dsel[posI, 4] != 0, , drop = FALSE]
         
         write.table(vcfHeader, file=fnames[i], quote=FALSE, sep="\t", col.names=FALSE, row.names=FALSE)
         suppressWarnings(write.table(out, file=fnames[i], quote=FALSE, sep="\t", append=TRUE, col.names=TRUE, row.names=FALSE))
@@ -352,7 +352,7 @@ exportSEG <- function(obj, fnames=NULL) {
         colnames(out) <- c("SAMPLE_NAME", "CHROMOSOME", "START", "STOP", "DATAPOINTS", "LOG2_RATIO_MEAN")
 
         ## Drop copy-neutral segments
-        out <- out[dsel[posI, 4] != 0, ]
+        out <- out[dsel[posI, 4] != 0, , drop = FALSE]
         
         write.table(out, file = fnames[i], quote=FALSE, sep="\t", append=FALSE, col.names=TRUE, row.names=FALSE)
         stopifnot(file_test("-f", fnames[i]))


### PR DESCRIPTION
This hopefully fixes #102, but this is untested. (I made the comment via the web editor, as I don't have any of Bioconductor installed at the moment.)